### PR TITLE
Upgrades: optimizations for listeners

### DIFF
--- a/src/main/java/org/example/harry/advancementsTogether/Listeners/BiomeListeners.java
+++ b/src/main/java/org/example/harry/advancementsTogether/Listeners/BiomeListeners.java
@@ -4,7 +4,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.advancement.Advancement;
 import org.bukkit.advancement.AdvancementProgress;
 import org.bukkit.block.Biome;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -14,60 +13,78 @@ import org.example.harry.advancementsTogether.config.MainConfigManager;
 import org.example.harry.advancementsTogether.managers.BiomeManager;
 import org.example.harry.advancementsTogether.utils.MessageUtils;
 
-import java.util.Iterator;
-import java.util.Set;
+import java.util.Optional;
 
 public class BiomeListeners implements Listener {
 
-    private Main plugin;
-    private BiomeManager biomeManager;
+    private final BiomeManager biomeManager;
+    private final MainConfigManager mainConfigManager;
+    private final String overworld;
+    private final String nether;
+    private final String theEnd;
+    private final Advancement adventuringTimeAdvancement;
 
-    public BiomeListeners(Main plugin, BiomeManager biomeManager){
-        this.plugin = plugin;
+    public BiomeListeners(Main plugin, BiomeManager biomeManager) {
         this.biomeManager = biomeManager;
+        this.mainConfigManager = plugin.getMainConfigManager();
+
+        this.overworld = mainConfigManager.getConfigOverworld();
+        this.nether = mainConfigManager.getConfigNether();
+        this.theEnd = mainConfigManager.getConfigEnd();
+
+        this.adventuringTimeAdvancement = Bukkit.getAdvancement(org.bukkit.NamespacedKey.minecraft("adventure/adventuring_time"));
     }
 
     @EventHandler
     public void onPlayerMove(PlayerMoveEvent event) {
-        Player player = event.getPlayer();
-        Advancement advancement = Bukkit.getAdvancement(org.bukkit.NamespacedKey.minecraft("adventure/adventuring_time"));
-        MainConfigManager mainConfigManager = plugin.getMainConfigManager();
-
-        String overworld = mainConfigManager.getConfigOverworld();
-        String nether = mainConfigManager.getConfigNether();
-        String theEnd = mainConfigManager.getConfigEnd();
-
-        for (Player p : Bukkit.getOnlinePlayers()) {
-            String playerWorld = p.getWorld().getName();
-
-            if (!playerWorld.equals(overworld) && !playerWorld.equals(nether) && !playerWorld.equals(theEnd)) {
-                return;
-            }
+        if (!isAnyPlayerInValidWorld()) {
+            return;
         }
 
-        if (biomeManager.getBiomesCount() >= 53){
-            if (advancement != null){
+        if (biomeManager.getBiomesCount() >= 53) {
+            grantAdvancementToAll();
+        }
+
+        Player player = event.getPlayer();
+        if (player.getWorld().getName().equalsIgnoreCase(overworld)) {
+            detectNewBiome(player);
+        }
+    }
+
+    private boolean isAnyPlayerInValidWorld() {
+        return Bukkit.getOnlinePlayers().stream()
+                .anyMatch(player -> {
+                    String world = player.getWorld().getName();
+                    return world.equals(overworld) || world.equals(nether) || world.equals(theEnd);
+                });
+    }
+
+    private void grantAdvancementToAll() {
+        Optional.ofNullable(adventuringTimeAdvancement).ifPresent(advancement -> {
+            for (Player player : Bukkit.getOnlinePlayers()) {
                 AdvancementProgress progress = player.getAdvancementProgress(advancement);
                 if (!progress.isDone()) {
-                    Iterator<String> criteria = progress.getRemainingCriteria().iterator();
-                    while (criteria.hasNext()) {
-                        progress.awardCriteria(criteria.next());
-                    }
+                    progress.getRemainingCriteria().forEach(progress::awardCriteria);
                 }
             }
-        }
+        });
+    }
 
-        if (player.getWorld().getName().equalsIgnoreCase(overworld)) {
-            Biome biome = player.getLocation().getBlock().getBiome();
-            String biomeString = String.valueOf(biome).replace("_", " ");
+    private void detectNewBiome(Player player) {
+        Biome biome = player.getLocation().getBlock().getBiome();
 
-            if (!biomeManager.isBiomeFound(biome)) {
-                biomeManager.addBiome(biome);
-                if (mainConfigManager.isMessagesFoundBiomesBoolean()){
-                    Bukkit.broadcastMessage(MessageUtils.getColoredMessage(Main.prefix + mainConfigManager.getMessagesFoundBiomes()
-                            .replace("%biome%", biomeString).replace("%player%", player.getName())
-                            .replace("%server_name%", Main.prefix).replace("%world%", player.getWorld().getName())));
-                }
+        if (!biomeManager.isBiomeFound(biome)) {
+            biomeManager.addBiome(biome);
+
+            if (mainConfigManager.isMessagesFoundBiomesBoolean()) {
+                String biomeString = biome.name().replace("_", " ");
+                String message = mainConfigManager.getMessagesFoundBiomes()
+                        .replace("%biome%", biomeString)
+                        .replace("%player%", player.getName())
+                        .replace("%server_name%", Main.prefix)
+                        .replace("%world%", player.getWorld().getName());
+
+                Bukkit.broadcastMessage(MessageUtils.getColoredMessage(Main.prefix + message));
             }
         }
     }

--- a/src/main/java/org/example/harry/advancementsTogether/Listeners/MobsListeners.java
+++ b/src/main/java/org/example/harry/advancementsTogether/Listeners/MobsListeners.java
@@ -1,9 +1,6 @@
 package org.example.harry.advancementsTogether.Listeners;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.advancement.Advancement;
-import org.bukkit.advancement.AdvancementProgress;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Monster;
 import org.bukkit.entity.Player;
@@ -12,60 +9,66 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.example.harry.advancementsTogether.Main;
 import org.example.harry.advancementsTogether.config.MainConfigManager;
-import org.example.harry.advancementsTogether.managers.BiomeManager;
 import org.example.harry.advancementsTogether.managers.MobsManager;
 import org.example.harry.advancementsTogether.utils.MessageUtils;
 
-import java.util.Iterator;
 import java.util.Set;
 
 public class MobsListeners implements Listener {
 
-    private Main plugin;
     private final MobsManager mobsManager;
+    private final MainConfigManager mainConfigManager;
 
-    public MobsListeners(Main plugin, MobsManager mobsManager) {
-        this.plugin = plugin;
-        this.mobsManager = mobsManager;
-    }
-
-    private final Set<EntityType> mobsEspecificos = Set.of(
+    private static final Set<EntityType> MOBS_ESPECIFICOS = Set.of(
             EntityType.SLIME, EntityType.GHAST,
             EntityType.MAGMA_CUBE, EntityType.SHULKER,
             EntityType.HOGLIN, EntityType.PHANTOM,
             EntityType.ENDER_DRAGON
     );
 
+    public MobsListeners(MainConfigManager mainConfigManager, MobsManager mobsManager) {
+        this.mainConfigManager = mainConfigManager;
+        this.mobsManager = mobsManager;
+    }
+
     @EventHandler
     public void onHostileMobDeath(EntityDeathEvent event) {
-
-        MainConfigManager mainConfigManager = plugin.getMainConfigManager();
-        EntityType mobType = event.getEntityType();
-        String entityType = String.valueOf(event.getEntityType()).replace("_", " ");
         Player killer = event.getEntity().getKiller();
+        EntityType mobType = event.getEntityType();
 
-        String overworld = mainConfigManager.getConfigOverworld();
-        String nether = mainConfigManager.getConfigNether();
-        String theEnd = mainConfigManager.getConfigEnd();
-
-        for (Player p : Bukkit.getOnlinePlayers()) {
-            String playerWorld = p.getWorld().getName();
-
-            if (!playerWorld.equals(overworld) && !playerWorld.equals(nether) && !playerWorld.equals(theEnd)) {
-                return;
-            }
+        if (killer == null || !isAnyPlayerInValidWorld()) {
+            return;
         }
 
-        if (event.getEntity() instanceof Monster || mobsEspecificos.contains(mobType) && mobType != EntityType.WARDEN) {
-            if (killer != null) {
-                if (!mobsManager.isMobFound(mobType)) {
-                    mobsManager.addMob(mobType);
-                    if (mainConfigManager.isMessagesFoundMobsBoolean()){
-                        Bukkit.broadcastMessage(MessageUtils.getColoredMessage(Main.prefix + mainConfigManager.getMessagesFoundMobs()
-                                .replace("%player%", killer.getName()).replace("%server_name%", Main.prefix)
-                                .replace("%mob%", entityType).replace("%world%", killer.getWorld().getName())));
-                    }
-                }
+        if (event.getEntity() instanceof Monster || MOBS_ESPECIFICOS.contains(mobType)) {
+            processMobDeath(killer, mobType);
+        }
+    }
+
+    private boolean isAnyPlayerInValidWorld() {
+        return Bukkit.getOnlinePlayers().stream()
+                .map(player -> player.getWorld().getName())
+                .anyMatch(world -> world.equals(mainConfigManager.getConfigOverworld()) ||
+                        world.equals(mainConfigManager.getConfigNether()) ||
+                        world.equals(mainConfigManager.getConfigEnd()));
+    }
+
+    private void processMobDeath(Player killer, EntityType mobType) {
+        if (!mobsManager.isMobFound(mobType)) {
+            mobsManager.addMob(mobType);
+
+            if (mainConfigManager.isMessagesFoundMobsBoolean()) {
+                String message = String.format(
+                        "%s%s",
+                        Main.prefix,
+                        mainConfigManager.getMessagesFoundMobs()
+                                .replace("%player%", killer.getName())
+                                .replace("%server_name%", Main.prefix)
+                                .replace("%mob%", mobType.name().replace("_", " "))
+                                .replace("%world%", killer.getWorld().getName())
+                );
+
+                Bukkit.broadcastMessage(MessageUtils.getColoredMessage(message));
             }
         }
     }

--- a/src/main/java/org/example/harry/advancementsTogether/Main.java
+++ b/src/main/java/org/example/harry/advancementsTogether/Main.java
@@ -91,7 +91,7 @@ public final class Main extends JavaPlugin {
     public void registerEvents(){
         getServer().getPluginManager().registerEvents(new PlayerListeners(this, advancementsUtils),this);
         getServer().getPluginManager().registerEvents(new BiomeListeners(this,biomeManager),this);
-        getServer().getPluginManager().registerEvents(new MobsListeners(this,mobsManager),this);
+        getServer().getPluginManager().registerEvents(new MobsListeners(mainConfigManager, mobsManager),this);
     }
 
     public MainConfigManager getMainConfigManager() {


### PR DESCRIPTION
Some things I optimized:

BiomeListeners:

        - Caching configuration values(overworld, nether and end config) instead of accessing them every time.
        - obtain Advancement only once and storing it.
        - Veryfing if the world is valid for an only player insted of the whole users on the server.

    
MobsListeners:
        - Modularization (main -> mainConfigManager)
        - removement of condition mobType != EntityType.WARDEN since WARDEN is not insede mobsEspecificos, so it will never 
          pass through mobsEspecificos.contains(mobType)
        - Making the set static makes it more efficient. 
        -extracted responsability (processMobDeath)
both:
  - optimization of every online player checking. 